### PR TITLE
Add ravens output

### DIFF
--- a/src/PowerModelsDistribution.jl
+++ b/src/PowerModelsDistribution.jl
@@ -70,6 +70,7 @@ module PowerModelsDistribution
     include("data_model/transformations/dss2eng.jl")
     include("data_model/transformations/eng2math.jl")
     include("data_model/transformations/math2eng.jl")
+    include("data_model/transformations/math2ravens.jl")
     include("data_model/transformations/utils.jl")
     include("data_model/transformations/reduce.jl")
     include("data_model/transformations/ravens2math.jl")

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -72,6 +72,7 @@ function transform_solution_ravens(
     solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"] = []
 
     # PowerFlow solutions for Transformers elements
+    seen_xfrmrs = Set{String}()     # Set to save xfrmr names
     for (xfrmr_number, xfrmr_data) in get(solution_math, "transformer", Dict{Any,Dict{String,Any}}())
 
         source_id_vect = split(data_math["transformer"][xfrmr_number]["source_id"], '.')
@@ -98,6 +99,21 @@ function transform_solution_ravens(
             push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
 
         end
+
+        if !(cond_eq_name in seen_xfrmrs)
+            xfrmr_status = data_math["transformer"][xfrmr_number]["status"] == 1 ? true : false
+            status_info = Dict(
+                "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                "AnalysisResultData.DataValues" => Dict(
+                    "AvStatus.inService" => xfrmr_status,
+                )
+            )
+            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+        end
+
+        # Store the xfrmr name
+        push!(seen_xfrmrs, "$(cond_eq_name)")
+
     end
 
 
@@ -233,10 +249,10 @@ function transform_solution_ravens(
 
     # @info "$(solution_ravens)"
 
-    # open("./OPFTEST-mod.json","w") do f
-    #     JSON.print(f, solution_ravens, 2)
-    # end
+    open("./OPFTEST-mod.json","w") do f
+        JSON.print(f, solution_ravens, 2)
+    end
 
-    # asdasd
+    asdasd
 
 end

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -23,10 +23,15 @@ function transform_solution_ravens(
     )
 
     # multinetwork/multiperiod support
+    mn_flag = false
     if ismultinetwork(data_math)
-        nws_math_data = data_math["nw"]
+        # Assumes there is at least nw=1
+        nws_math_data = data_math["nw"]["1"]
+        solution = solution_math["nw"]["1"]
+        mn_flag = true
     else
         nws_math_data = data_math
+        solution = solution_math
     end
 
     # Create OptimalPowerFlow AnalysisResult Dictionary
@@ -56,19 +61,19 @@ function transform_solution_ravens(
     # PowerFlow solutions for Transformers elements
     seen_xfrmrs = Set{String}()     # Set to save xfrmr names
 
-    # Multinetwork support
-    if ismultinetwork(data_math)
+    # Buses/ConnectivityNodes
+    for (node_number, node_data) in solution["bus"]
 
-        # # Buses/ConnectivityNodes --- Assummes there is at least nw=1
-        for (node_number, node_data) in solution_math["nw"]["1"]["bus"]
+        # Extract the phases for the node
+        node_terminals = nws_math_data["bus"][node_number]["terminals"]
+        phase_kinds = [phase_mapping[x] for x in node_terminals]
 
-            # Extract the phases for the node
-            node_terminals = nws_math_data["1"]["bus"][node_number]["terminals"]
-            phase_kinds = [phase_mapping[x] for x in node_terminals]
+        for (i, result_phase) in enumerate(phase_kinds)
 
-            for (i, result_phase) in enumerate(phase_kinds)
+            conn_node = split(nws_math_data["bus"][node_number]["source_id"], '.')[2]
 
-                conn_node = split(nws_math_data["1"]["bus"][node_number]["source_id"], '.')[2]
+            # Multinetwork support
+            if mn_flag == true
 
                 # Curve data
                 mn_data = Dict()
@@ -79,14 +84,14 @@ function transform_solution_ravens(
 
                 for (nw, nw_data) in solution_math["nw"]
                     mn_info = Dict(
-                            "ArCurveData.xvalue" => parse(Float64, nw),
-                            "ArCurveData.DataValues" => Dict(
-                                "AvVoltage.v" => solution_math["nw"][nw]["bus"][node_number]["vm"][i]*solution_math["nw"][nw]["settings"]["voltage_scale_factor"],
-                                "AvVoltage.angle" => solution_math["nw"][nw]["bus"][node_number]["va"][i],
-                                "Ravens.cimObjectType" => "AvVoltage",
-                            ),
-                        )
-                     push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
+                        "ArCurveData.xvalue" => parse(Float64, nw),
+                        "ArCurveData.DataValues" => Dict(
+                            "AvVoltage.v" => solution_math["nw"][nw]["bus"][node_number]["vm"][i]*solution_math["nw"][nw]["settings"]["voltage_scale_factor"],
+                            "AvVoltage.angle" => solution_math["nw"][nw]["bus"][node_number]["va"][i],
+                            "Ravens.cimObjectType" => "AvVoltage",
+                        ),
+                    )
+                    push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
                 end
 
                 voltage_info = Dict(
@@ -94,26 +99,8 @@ function transform_solution_ravens(
                     "ArVoltage.ConnectivityNode" => "ConnectivityNode::'$(conn_node)'",
                     "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
                 )
-                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"], voltage_info)
 
-            end
-        end
-
-
-
-
-
-
-    else
-
-        # Buses/ConnectivityNodes
-        for (node_number, node_data) in solution_math["bus"]
-            # Extract the phases for the node
-            node_terminals = nws_math_data["bus"][node_number]["terminals"]
-            phase_kinds = [phase_mapping[x] for x in node_terminals]
-
-            for (i, result_phase) in enumerate(phase_kinds)
-                conn_node = split(nws_math_data["bus"][node_number]["source_id"], '.')[2]
+            else
                 voltage_info = Dict(
                     "AnalysisResultData.phase" => result_phase,
                     "ArVoltage.ConnectivityNode" => "ConnectivityNode::'$(conn_node)'",
@@ -123,24 +110,60 @@ function transform_solution_ravens(
                         "Ravens.cimObjectType" => "AvVoltage",
                     ),
                 )
-                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"], voltage_info)
             end
+
+            # Push info to final dictionary
+            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"], voltage_info)
+
         end
 
-        # Transformers
-        for (xfrmr_number, xfrmr_data) in get(solution_math, "transformer", Dict{Any,Dict{String,Any}}())
+    end
 
-            # Extract data
-            source_id_vect = split(nws_math_data["transformer"][xfrmr_number]["source_id"], '.')
-            cond_eq_type = source_id_vect[2]
-            cond_eq_name = source_id_vect[3]
-            end_num = parse(Int, source_id_vect[4])
+    # Transformers
+    for (xfrmr_number, xfrmr_data) in get(solution, "transformer", Dict{Any,Dict{String,Any}}())
 
-            # Extract the phases for the branch
-            terminals = nws_math_data["transformer"][xfrmr_number]["f_connections"]
-            phase_kinds = [phase_mapping[x] for x in terminals]
+        # Extract data
+        source_id_vect = split(nws_math_data["transformer"][xfrmr_number]["source_id"], '.')
+        cond_eq_type = source_id_vect[2]
+        cond_eq_name = source_id_vect[3]
+        end_num = parse(Int, source_id_vect[4])
 
-            for (i, result_phase) in enumerate(phase_kinds)
+        # Extract the phases for the branch
+        terminals = nws_math_data["transformer"][xfrmr_number]["f_connections"]
+        phase_kinds = [phase_mapping[x] for x in terminals]
+
+        for (i, result_phase) in enumerate(phase_kinds)
+
+            # Multinetwork support
+            if mn_flag == true
+
+                # Curve data
+                mn_data = Dict()
+                mn_data["AnalysisResultData.Curve"] = Dict()
+                # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
+                mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
+                mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
+
+                for (nw, nw_data) in solution_math["nw"]
+                    mn_info = Dict(
+                        "ArCurveData.xvalue" => parse(Float64, nw),
+                        "ArCurveData.DataValues" => Dict(
+                            "AvPowerFlow.p" => solution_math["nw"][nw]["transformer"][xfrmr_number]["pf"][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
+                            "AvPowerFlow.q" => solution_math["nw"][nw]["transformer"][xfrmr_number]["qf"][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
+                            "AvPowerFlow.endNumber" => end_num,
+                            "Ravens.cimObjectType" => "ArPowerFlow",
+                        ),
+                    )
+                    push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
+                end
+
+                pf_info = Dict(
+                    "AnalysisResultData.phase" => result_phase,
+                    "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                    "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
+                )
+
+            else
 
                 pf_info = Dict(
                     "AnalysisResultData.phase" => result_phase,
@@ -152,74 +175,173 @@ function transform_solution_ravens(
                         "Ravens.cimObjectType" => "ArPowerFlow",
                     ),
                 )
-                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+
 
             end
 
-            if !(cond_eq_name in seen_xfrmrs)
-                xfrmr_status = nws_math_data["transformer"][xfrmr_number]["status"] == 1 ? true : false
+            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+
+        end
+
+        # Status for Xfrmrs
+        if !(cond_eq_name in seen_xfrmrs)
+
+            xfrmr_status = nws_math_data["transformer"][xfrmr_number]["status"] == 1 ? true : false
+
+            # Multinetwork support
+            if mn_flag == true
+
+                # Curve data
+                mn_data = Dict()
+                mn_data["AnalysisResultData.Curve"] = Dict()
+                # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
+                mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
+                mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
+
+                for (nw, nw_data) in solution_math["nw"]
+                    mn_info = Dict(
+                        "ArCurveData.xvalue" => parse(Float64, nw),
+                        "ArCurveData.DataValues" => Dict(
+                            "AvStatus.inService" => xfrmr_status
+                        ),
+                    )
+                    push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
+                end
+
+                status_info = Dict(
+                    "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                    "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
+                )
+
+            else
+
                 status_info = Dict(
                     "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
                     "AnalysisResultData.DataValues" => Dict(
                         "AvStatus.inService" => xfrmr_status,
                     )
                 )
-                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+
             end
 
-            # Store the xfrmr name
-            push!(seen_xfrmrs, "$(cond_eq_name)")
+            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
 
         end
 
-        # Edge elements (branches, switches)
-        edge_elements = ["branch", "switch"]
-        for edge_elmnt in edge_elements
+        # Store the xfrmr name
+        push!(seen_xfrmrs, "$(cond_eq_name)")
 
-            for (edge_number, edge_data) in get(solution_math, edge_elmnt, Dict{Any,Dict{String,Any}}())
+    end
 
-                # Filter virtual elements that exist in the MATH model
-                if !occursin("virtual", nws_math_data[edge_elmnt][edge_number]["name"])
+    # Edge elements (branches, switches)
+    edge_elements = ["branch", "switch"]
+    for edge_elmnt in edge_elements
 
-                    cond_eq_type = split(nws_math_data[edge_elmnt][edge_number]["source_id"], '.')[1]
-                    cond_eq_name = split(nws_math_data[edge_elmnt][edge_number]["source_id"], '.')[2]
+        for (edge_number, edge_data) in get(solution, edge_elmnt, Dict{Any,Dict{String,Any}}())
 
-                    # Add Switch state (only switches)
-                    if edge_elmnt == "switch"
-                        sw_state = nws_math_data[edge_elmnt][edge_number]["state"] == 1 ? false : true
-                        state_info = Dict(
-                        "ArSwitch.Switch" => "$(cond_eq_type)::'$(cond_eq_name)'",
-                        "AnalysisResultData.DataValues" => Dict(
-                            "AvSwitch.open" => sw_state,
+            # Filter virtual elements that exist in the MATH model
+            if !occursin("virtual", nws_math_data[edge_elmnt][edge_number]["name"])
+
+                cond_eq_type = split(nws_math_data[edge_elmnt][edge_number]["source_id"], '.')[1]
+                cond_eq_name = split(nws_math_data[edge_elmnt][edge_number]["source_id"], '.')[2]
+
+                # Add Switch state (only switches)
+                if edge_elmnt == "switch"
+
+                    sw_state = nws_math_data[edge_elmnt][edge_number]["state"] == 1 ? false : true
+
+                    if mn_flag == true
+
+                        # Curve data
+                        mn_data = Dict()
+                        mn_data["AnalysisResultData.Curve"] = Dict()
+                        # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
+                        mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
+                        mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
+
+                        for (nw, nw_data) in solution_math["nw"]
+                            mn_info = Dict(
+                                "ArCurveData.xvalue" => parse(Float64, nw),
+                                "ArCurveData.DataValues" => Dict(
+                                    "AvSwitch.open" => sw_state,
+                                ),
                             )
-                        )
-                        push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Switches"], state_info)
-                    end
-
-
-                    num_ends = 2
-                    # # OPTIONAL opt out of edge elements beside transformers to write from and to flows
-                    # if edge_elmnt != "transformer"
-                    #     num_ends = 1
-                    # end
-
-                    for end_num in 1:num_ends # loop through ends
-                        if end_num == 1
-                            connection_flow = "f_connections"
-                            p_flow_direction = "pf"
-                            q_flow_direction = "qf"
-                        else end_num == 2
-                            connection_flow = "t_connections"
-                            p_flow_direction = "pt"
-                            q_flow_direction = "qt"
+                            push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
                         end
 
-                        # Extract the phases for the branch
-                        terminals = nws_math_data[edge_elmnt][edge_number][connection_flow]
-                        phase_kinds = [phase_mapping[x] for x in terminals]
+                        state_info = Dict(
+                            "ArSwitch.Switch" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                            "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
+                        )
 
-                        for (i, result_phase) in enumerate(phase_kinds)
+                    else
+                        state_info = Dict(
+                            "ArSwitch.Switch" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                            "AnalysisResultData.DataValues" => Dict(
+                                "AvSwitch.open" => sw_state,
+                            )
+                        )
 
+                    end
+
+                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Switches"], state_info)
+
+                end
+
+
+                num_ends = 2
+                # # OPTIONAL opt out of edge elements to write from and to flows
+                # if edge_elmnt != "transformer"
+                #     num_ends = 1
+                # end
+
+                for end_num in 1:num_ends # loop through ends
+                    if end_num == 1
+                        connection_flow = "f_connections"
+                        p_flow_direction = "pf"
+                        q_flow_direction = "qf"
+                    else end_num == 2
+                        connection_flow = "t_connections"
+                        p_flow_direction = "pt"
+                        q_flow_direction = "qt"
+                    end
+
+                    # Extract the phases for the branch
+                    terminals = nws_math_data[edge_elmnt][edge_number][connection_flow]
+                    phase_kinds = [phase_mapping[x] for x in terminals]
+
+                    for (i, result_phase) in enumerate(phase_kinds)
+
+                        # Multinetwork support
+                        if mn_flag == true
+
+                            # Curve data
+                            mn_data = Dict()
+                            mn_data["AnalysisResultData.Curve"] = Dict()
+                            # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
+                            mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
+                            mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
+
+                            for (nw, nw_data) in solution_math["nw"]
+                                mn_info = Dict(
+                                    "ArCurveData.xvalue" => parse(Float64, nw),
+                                    "ArCurveData.DataValues" => Dict(
+                                        "AvPowerFlow.p" => solution_math["nw"][nw][edge_elmnt][edge_number][p_flow_direction][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
+                                        "AvPowerFlow.q" => solution_math["nw"][nw][edge_elmnt][edge_number][q_flow_direction][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
+                                        "AvPowerFlow.endNumber" => end_num,
+                                        "Ravens.cimObjectType" => "ArPowerFlow",
+                                    ),
+                                )
+                                push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
+                            end
+
+                            pf_info = Dict(
+                                "AnalysisResultData.phase" => result_phase,
+                                "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                                "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
+                            )
+
+                        else
                             pf_info = Dict(
                                 "AnalysisResultData.phase" => result_phase,
                                 "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
@@ -230,59 +352,124 @@ function transform_solution_ravens(
                                     "Ravens.cimObjectType" => "ArPowerFlow",
                                 ),
                             )
-                            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
 
                         end
+
+                        push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+
+                    end
+                end
+
+                # Statuses
+                object_prefix = ""
+                if edge_elmnt == "branch"
+                    object_prefix = "br_"
+                end
+
+                elemtn_status = nws_math_data[edge_elmnt][edge_number]["$(object_prefix)status"] == 1 ? true : false
+
+                # Multinetwork support
+                if mn_flag == true
+
+                    # Curve data
+                    mn_data = Dict()
+                    mn_data["AnalysisResultData.Curve"] = Dict()
+                    # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
+                    mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
+                    mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
+
+                    for (nw, nw_data) in solution_math["nw"]
+                        mn_info = Dict(
+                            "ArCurveData.xvalue" => parse(Float64, nw),
+                            "ArCurveData.DataValues" => Dict(
+                                "AvStatus.inService" => elemtn_status
+                            ),
+                        )
+                        push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
                     end
 
-                    # Statuses
-                    object_prefix = ""
-                    if edge_elmnt == "branch"
-                        object_prefix = "br_"
-                    end
+                    status_info = Dict(
+                        "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                        "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
+                    )
 
-                    elemtn_status = nws_math_data[edge_elmnt][edge_number]["$(object_prefix)status"] == 1 ? true : false
+                else
+
                     status_info = Dict(
                         "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
                         "AnalysisResultData.DataValues" => Dict(
                             "AvStatus.inService" => elemtn_status,
                         )
                     )
-                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
 
                 end
 
+                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+
             end
+
         end
+    end
 
-        # Nodal elements (loads, gens)
-        node_elements = ["load", "gen"]
-        for node_elmnt in node_elements
+    # Nodal elements (loads, gens)
+    node_elements = ["load", "gen"]
+    for node_elmnt in node_elements
 
-            for (node_number, node_data) in get(solution_math, node_elmnt, Dict{Any,Dict{String,Any}}())
+        for (node_number, node_data) in get(solution, node_elmnt, Dict{Any,Dict{String,Any}}())
 
-                # Filter virtual elements that exist in the MATH model
-                if !occursin("virtual", nws_math_data[node_elmnt][node_number]["name"])
+            # Filter virtual elements that exist in the MATH model
+            if !occursin("virtual", nws_math_data[node_elmnt][node_number]["name"])
 
-                    cond_eq_type = split(nws_math_data[node_elmnt][node_number]["source_id"], '.')[1]
-                    cond_eq_name = split(nws_math_data[node_elmnt][node_number]["source_id"], '.')[2]
+                cond_eq_type = split(nws_math_data[node_elmnt][node_number]["source_id"], '.')[1]
+                cond_eq_name = split(nws_math_data[node_elmnt][node_number]["source_id"], '.')[2]
 
-                    if node_elmnt == "load"
-                        p_key = "pd"
-                        q_key = "qd"
-                    elseif node_elmnt == "gen"
-                        p_key = "pg"
-                        q_key = "qg"
+                if node_elmnt == "load"
+                    p_key = "pd"
+                    q_key = "qd"
+                elseif node_elmnt == "gen"
+                    p_key = "pg"
+                    q_key = "qg"
+                else
+                    p_key = "p"
+                    q_key = "q"
+                end
+
+                # Extract the phases for the node element
+                terminals = nws_math_data[node_elmnt][node_number]["connections"]
+                phase_kinds = [phase_mapping[x] for x in terminals]
+
+                for (i, result_phase) in enumerate(phase_kinds)
+
+                    # Multinetwork support
+                    if mn_flag == true
+
+                        # Curve data
+                        mn_data = Dict()
+                        mn_data["AnalysisResultData.Curve"] = Dict()
+                        # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
+                        mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
+                        mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
+
+                        for (nw, nw_data) in solution_math["nw"]
+                            mn_info = Dict(
+                                "ArCurveData.xvalue" => parse(Float64, nw),
+                                "ArCurveData.DataValues" => Dict(
+                                    "AvPowerFlow.p" => solution_math["nw"][nw][node_elmnt][node_number][p_key][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
+                                    "AvPowerFlow.q" => solution_math["nw"][nw][node_elmnt][node_number][q_key][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
+                                    "Ravens.cimObjectType" => "ArPowerFlow",
+                                ),
+                            )
+                            push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
+                        end
+
+                        pf_info = Dict(
+                            "AnalysisResultData.phase" => result_phase,
+                            "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                            "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
+                        )
+
+
                     else
-                        p_key = "p"
-                        q_key = "q"
-                    end
-
-                    # Extract the phases for the node element
-                    terminals = nws_math_data[node_elmnt][node_number]["connections"]
-                    phase_kinds = [phase_mapping[x] for x in terminals]
-
-                    for (i, result_phase) in enumerate(phase_kinds)
 
                         pf_info = Dict(
                             "AnalysisResultData.phase" => result_phase,
@@ -293,30 +480,63 @@ function transform_solution_ravens(
                                 "Ravens.cimObjectType" => "ArPowerFlow",
                             ),
                         )
-                        push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+
                     end
 
+                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
 
-                    # Statuses
-                    object_prefix = ""
-                    if node_elmnt == "gen"
-                        object_prefix = "gen_"
+                end
+
+
+                # Statuses
+                object_prefix = ""
+                if node_elmnt == "gen"
+                    object_prefix = "gen_"
+                end
+
+                elemtn_status = nws_math_data[node_elmnt][node_number]["$(object_prefix)status"] == 1 ? true : false
+
+                # Multinetwork support
+                if mn_flag == true
+
+                    # Curve data
+                    mn_data = Dict()
+                    mn_data["AnalysisResultData.Curve"] = Dict()
+                    # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
+                    mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
+                    mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
+
+                    for (nw, nw_data) in solution_math["nw"]
+                        mn_info = Dict(
+                            "ArCurveData.xvalue" => parse(Float64, nw),
+                            "ArCurveData.DataValues" => Dict(
+                                "AvStatus.inService" => elemtn_status
+                            ),
+                        )
+                        push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
                     end
 
-                    elemtn_status = nws_math_data[node_elmnt][node_number]["$(object_prefix)status"] == 1 ? true : false
+                    status_info = Dict(
+                        "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                        "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
+                    )
+
+                else
+
                     status_info = Dict(
                         "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
                         "AnalysisResultData.DataValues" => Dict(
                             "AvStatus.inService" => elemtn_status,
                         )
                     )
-                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+
                 end
+
+                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+
             end
         end
-
     end
-
 
     return solution_ravens
 

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -87,10 +87,15 @@ function transform_solution_ravens(
                         "ArCurveData.xvalue" => parse(Float64, nw),
                         "ArCurveData.DataValues" => Dict(
                             "AvVoltage.v" => solution_math["nw"][nw]["bus"][node_number]["vm"][i]*solution_math["nw"][nw]["settings"]["voltage_scale_factor"],
-                            "AvVoltage.angle" => solution_math["nw"][nw]["bus"][node_number]["va"][i],
                             "Ravens.cimObjectType" => "AvVoltage",
                         ),
                     )
+
+                    # Conditionally add the angle (some do not have it)
+                    if haskey(solution_math["nw"][nw]["bus"][node_number], "va")
+                        mn_info["ArCurveData.DataValues"]["AvVoltage.angle"] = solution_math["nw"][nw]["bus"][node_number]["va"][i]
+                    end
+
                     push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
                 end
 
@@ -248,6 +253,7 @@ function transform_solution_ravens(
                 # Add Switch state (only switches)
                 if edge_elmnt == "switch"
 
+                    # initial state from math network data
                     sw_state = nws_math_data[edge_elmnt][edge_number]["state"] == 1 ? false : true
 
                     if mn_flag == true
@@ -260,6 +266,7 @@ function transform_solution_ravens(
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                         for (nw, nw_data) in solution_math["nw"]
+                            sw_state = Int(nw_data[edge_elmnt][edge_number]["state"]) == 0 ? true : false
                             mn_info = Dict(
                                 "ArCurveData.xvalue" => parse(Float64, nw),
                                 "ArCurveData.DataValues" => Dict(
@@ -494,6 +501,7 @@ function transform_solution_ravens(
                     object_prefix = "gen_"
                 end
 
+                # original status from math data
                 elemtn_status = nws_math_data[node_elmnt][node_number]["$(object_prefix)status"] == 1 ? true : false
 
                 # Multinetwork support
@@ -507,6 +515,7 @@ function transform_solution_ravens(
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                     for (nw, nw_data) in solution_math["nw"]
+                        elemtn_status = Int(nw_data[node_elmnt][node_number]["status"]) == 1 ? true : false
                         mn_info = Dict(
                             "ArCurveData.xvalue" => parse(Float64, nw),
                             "ArCurveData.DataValues" => Dict(

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -1,0 +1,242 @@
+function transform_solution_ravens(
+    solution_math::Dict{String,<:Any},
+    data_math::Dict{String,<:Any};
+    map::Union{Vector{<:Dict{String,<:Any}},Missing}=missing,
+    make_si::Bool=true,
+    convert_rad2deg::Bool=true,
+     map_math2eng_extensions::Dict{String,<:Function}=Dict{String,Function}(),
+    make_si_extensions::Vector{<:Function}=Function[],
+    dimensionalize_math_extensions::Dict{String,<:Dict{String,<:Vector{<:String}}}=Dict{String,Dict{String,Vector{String}}}()
+)::Dict{String,Any}
+
+    @assert ismath(data_math) "cannot be converted. Not a MATH model."
+
+    # convert solution to si?
+    solution_math = solution_make_si(
+        solution_math,
+        data_math;
+        mult_vbase=make_si,
+        mult_sbase=make_si,
+        convert_rad2deg=convert_rad2deg,
+        make_si_extensions=make_si_extensions,
+        dimensionalize_math_extensions=dimensionalize_math_extensions
+    )
+
+    # TODO: multinetwork/multiperiod support
+    # if ismultinetwork(data_math)
+    #     nws_math_sol = get(solution_math, "nw", Dict{String,Any}())
+    #     nws_math_data = data_math["nw"]
+    # else
+    #     nws_math_sol = Dict("0" => solution_math)
+    #     nws_math_data = Dict("0" => data_math)
+    # end
+
+    # Create OptimalPowerFlow AnalysisResult Dictionary
+    # TODO: read original JSON file, and add result to that JSON file (check if AnalysisResult exists before overwriting it)
+    solution_ravens = Dict()
+    solution_ravens["AnalysisResult"] = Dict()
+    solution_ravens["AnalysisResult"]["OptimalPowerFlow"] = Dict()
+    solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["Ravens.cimObjectType"] = "OperationsResult"
+    solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["IdentifiedObject.name"] = "OptimalPowerFlow"
+    solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["IdentifiedObject.mRID"] = "#_$(uppercase(string(UUIDs.uuid4())))"
+
+    # Create a mapping from integers to strings
+    phase_mapping = Dict(1 => "SinglePhaseKind.A", 2 => "SinglePhaseKind.B", 3 => "SinglePhaseKind.C")
+
+    # Voltages
+    solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"] = []
+    for (node_number, node_data) in solution_math["bus"]
+        # Extract the phases for the node
+        node_terminals = data_math["bus"][node_number]["terminals"]
+        phase_kinds = [phase_mapping[x] for x in node_terminals]
+
+        for (i, result_phase) in enumerate(phase_kinds)
+            conn_node = split(data_math["bus"][node_number]["source_id"], '.')[2]
+            voltage_info = Dict(
+                "AnalysisResultData.phase" => result_phase,
+                "ArVoltage.ConnectivityNode" => "ConnectivityNode::'$(conn_node)'",
+                "AnalysisResultData.DataValues" => Dict(
+                    "AvVoltage.v" => node_data["vm"][i]*solution_math["settings"]["voltage_scale_factor"],
+                    "AvVoltage.angle" => node_data["va"][i],
+                    "Ravens.cimObjectType" => "AvVoltage",
+                ),
+            )
+            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"], voltage_info)
+        end
+    end
+
+    # PowerFlows
+    solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"] = []
+
+    # Statuses
+    solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"] = []
+
+    # PowerFlow solutions for Transformers elements
+    for (xfrmr_number, xfrmr_data) in get(solution_math, "transformer", Dict{Any,Dict{String,Any}}())
+
+        source_id_vect = split(data_math["transformer"][xfrmr_number]["source_id"], '.')
+        cond_eq_type = source_id_vect[2]
+        cond_eq_name = source_id_vect[3]
+        end_num = parse(Int, source_id_vect[4])
+
+        # Extract the phases for the branch
+        terminals = data_math["transformer"][xfrmr_number]["f_connections"]
+        phase_kinds = [phase_mapping[x] for x in terminals]
+
+        for (i, result_phase) in enumerate(phase_kinds)
+
+            pf_info = Dict(
+                "AnalysisResultData.phase" => result_phase,
+                "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                "AnalysisResultData.DataValues" => Dict(
+                    "AvPowerFlow.p" => xfrmr_data["pf"][i]*solution_math["settings"]["power_scale_factor"],
+                    "AvPowerFlow.q" => xfrmr_data["qf"][i]*solution_math["settings"]["power_scale_factor"],
+                    "AvPowerFlow.endNumber" => end_num,
+                    "Ravens.cimObjectType" => "ArPowerFlow",
+                ),
+            )
+            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+
+        end
+    end
+
+
+    edge_elements = ["branch", "switch"]
+    for edge_elmnt in edge_elements
+
+        for (edge_number, edge_data) in get(solution_math, edge_elmnt, Dict{Any,Dict{String,Any}}())
+
+            # Filter virtual elements that exist in the MATH model
+            if !occursin("virtual", data_math[edge_elmnt][edge_number]["name"])
+
+                cond_eq_type = split(data_math[edge_elmnt][edge_number]["source_id"], '.')[1]
+                cond_eq_name = split(data_math[edge_elmnt][edge_number]["source_id"], '.')[2]
+
+                num_ends = 2
+                # # OPTIONAL opt out of edge elements beside transformers to write from and to flows
+                # if edge_elmnt != "transformer"
+                #     num_ends = 1
+                # end
+
+                for end_num in 1:num_ends # loop through ends
+                    if end_num == 1
+                        connection_flow = "f_connections"
+                        p_flow_direction = "pf"
+                        q_flow_direction = "qf"
+                    else end_num == 2
+                        connection_flow = "t_connections"
+                        p_flow_direction = "pt"
+                        q_flow_direction = "qt"
+                    end
+
+                    # Extract the phases for the branch
+                    terminals = data_math[edge_elmnt][edge_number][connection_flow]
+                    phase_kinds = [phase_mapping[x] for x in terminals]
+
+                    for (i, result_phase) in enumerate(phase_kinds)
+
+                        pf_info = Dict(
+                            "AnalysisResultData.phase" => result_phase,
+                            "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                            "AnalysisResultData.DataValues" => Dict(
+                                "AvPowerFlow.p" => edge_data[p_flow_direction][i]*solution_math["settings"]["power_scale_factor"],
+                                "AvPowerFlow.q" => edge_data[q_flow_direction][i]*solution_math["settings"]["power_scale_factor"],
+                                "AvPowerFlow.endNumber" => end_num,
+                                "Ravens.cimObjectType" => "ArPowerFlow",
+                            ),
+                        )
+                        push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+
+                    end
+                end
+
+                # Statuses
+                object_prefix = ""
+                if edge_elmnt == "branch"
+                    object_prefix = "br_"
+                end
+
+                elemtn_status = data_math[edge_elmnt][edge_number]["$(object_prefix)status"] == 1 ? true : false
+                status_info = Dict(
+                    "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                    "AnalysisResultData.DataValues" => Dict(
+                        "AvStatus.inService" => elemtn_status,
+                    )
+                )
+                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+
+            end
+
+        end
+    end
+
+    #  PowerFlow solutions for Node elements
+    node_elements = ["load", "gen"]
+    for node_elmnt in node_elements
+
+        for (node_number, node_data) in get(solution_math, node_elmnt, Dict{Any,Dict{String,Any}}())
+
+            # Filter virtual elements that exist in the MATH model
+            if !occursin("virtual", data_math[node_elmnt][node_number]["name"])
+
+                cond_eq_type = split(data_math[node_elmnt][node_number]["source_id"], '.')[1]
+                cond_eq_name = split(data_math[node_elmnt][node_number]["source_id"], '.')[2]
+
+                if node_elmnt == "load"
+                    p_key = "pd"
+                    q_key = "qd"
+                elseif node_elmnt == "gen"
+                    p_key = "pg"
+                    q_key = "qg"
+                else
+                    p_key = "p"
+                    q_key = "q"
+                end
+
+                # Extract the phases for the node element
+                terminals = data_math[node_elmnt][node_number]["connections"]
+                phase_kinds = [phase_mapping[x] for x in terminals]
+
+                for (i, result_phase) in enumerate(phase_kinds)
+
+                    pf_info = Dict(
+                        "AnalysisResultData.phase" => result_phase,
+                        "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                        "AnalysisResultData.DataValues" => Dict(
+                            "AvPowerFlow.p" => node_data[p_key][i]*solution_math["settings"]["power_scale_factor"],
+                            "AvPowerFlow.q" => node_data[q_key][i]*solution_math["settings"]["power_scale_factor"],
+                            "Ravens.cimObjectType" => "ArPowerFlow",
+                        ),
+                    )
+                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+                end
+
+
+                # Statuses
+                object_prefix = ""
+                if node_elmnt == "gen"
+                    object_prefix = "gen_"
+                end
+
+                elemtn_status = data_math[node_elmnt][node_number]["$(object_prefix)status"] == 1 ? true : false
+                status_info = Dict(
+                    "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                    "AnalysisResultData.DataValues" => Dict(
+                        "AvStatus.inService" => elemtn_status,
+                    )
+                )
+                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+            end
+        end
+    end
+
+
+    # @info "$(solution_ravens)"
+
+    # open("./OPFTEST-mod.json","w") do f
+    #     JSON.print(f, solution_ravens, 2)
+    # end
+
+    # asdasd
+
+end

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -265,7 +265,9 @@ function transform_solution_ravens(
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                         for (nw, nw_data) in solution_math["nw"]
-                            sw_state = Int(nw_data[edge_elmnt][edge_number]["state"]) == 0 ? true : false
+                            if haskey(nw_data[edge_elmnt][edge_number], "state")
+                                sw_state = Int(nw_data[edge_elmnt][edge_number]["state"]) == 0 ? true : false
+                            end
                             mn_info = Dict(
                                 "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                                 "ArCurveData.DataValues" => Dict(
@@ -513,7 +515,9 @@ function transform_solution_ravens(
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                     for (nw, nw_data) in solution_math["nw"]
-                        elemtn_status = Int(nw_data[node_elmnt][node_number]["status"]) == 1 ? true : false
+                        if haskey(nw_data[node_elmnt][node_number], "status")
+                            elemtn_status = Int(nw_data[node_elmnt][node_number]["status"]) == 1 ? true : false
+                        end
                         mn_info = Dict(
                             "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                             "ArCurveData.DataValues" => Dict(

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -34,6 +34,9 @@ function transform_solution_ravens(
         solution = solution_math
     end
 
+    # Get time_elapsed to compute time steps -- default is 1.0 hour.
+    time_elapsed = get(data_math, "time_elapsed", 1.0)
+
     # Create OptimalPowerFlow AnalysisResult Dictionary
     # TODO: read original JSON file, and add result to that JSON file (check if AnalysisResult exists before overwriting it)
     solution_ravens = Dict()
@@ -78,13 +81,12 @@ function transform_solution_ravens(
                 # Curve data
                 mn_data = Dict()
                 mn_data["AnalysisResultData.Curve"] = Dict()
-                # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                 for (nw, nw_data) in solution_math["nw"]
                     mn_info = Dict(
-                        "ArCurveData.xvalue" => parse(Float64, nw),
+                        "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                         "ArCurveData.DataValues" => Dict(
                             "AvVoltage.v" => solution_math["nw"][nw]["bus"][node_number]["vm"][i]*solution_math["nw"][nw]["settings"]["voltage_scale_factor"],
                             "Ravens.cimObjectType" => "AvVoltage",
@@ -145,13 +147,12 @@ function transform_solution_ravens(
                 # Curve data
                 mn_data = Dict()
                 mn_data["AnalysisResultData.Curve"] = Dict()
-                # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                 for (nw, nw_data) in solution_math["nw"]
                     mn_info = Dict(
-                        "ArCurveData.xvalue" => parse(Float64, nw),
+                        "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                         "ArCurveData.DataValues" => Dict(
                             "AvPowerFlow.p" => solution_math["nw"][nw]["transformer"][xfrmr_number]["pf"][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
                             "AvPowerFlow.q" => solution_math["nw"][nw]["transformer"][xfrmr_number]["qf"][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
@@ -199,13 +200,12 @@ function transform_solution_ravens(
                 # Curve data
                 mn_data = Dict()
                 mn_data["AnalysisResultData.Curve"] = Dict()
-                # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                 for (nw, nw_data) in solution_math["nw"]
                     mn_info = Dict(
-                        "ArCurveData.xvalue" => parse(Float64, nw),
+                        "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                         "ArCurveData.DataValues" => Dict(
                             "AvStatus.inService" => xfrmr_status
                         ),
@@ -261,14 +261,13 @@ function transform_solution_ravens(
                         # Curve data
                         mn_data = Dict()
                         mn_data["AnalysisResultData.Curve"] = Dict()
-                        # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                         for (nw, nw_data) in solution_math["nw"]
                             sw_state = Int(nw_data[edge_elmnt][edge_number]["state"]) == 0 ? true : false
                             mn_info = Dict(
-                                "ArCurveData.xvalue" => parse(Float64, nw),
+                                "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                                 "ArCurveData.DataValues" => Dict(
                                     "AvSwitch.open" => sw_state,
                                 ),
@@ -325,13 +324,12 @@ function transform_solution_ravens(
                             # Curve data
                             mn_data = Dict()
                             mn_data["AnalysisResultData.Curve"] = Dict()
-                            # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
                             mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                             mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                             for (nw, nw_data) in solution_math["nw"]
                                 mn_info = Dict(
-                                    "ArCurveData.xvalue" => parse(Float64, nw),
+                                    "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                                     "ArCurveData.DataValues" => Dict(
                                         "AvPowerFlow.p" => solution_math["nw"][nw][edge_elmnt][edge_number][p_flow_direction][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
                                         "AvPowerFlow.q" => solution_math["nw"][nw][edge_elmnt][edge_number][q_flow_direction][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
@@ -381,13 +379,12 @@ function transform_solution_ravens(
                     # Curve data
                     mn_data = Dict()
                     mn_data["AnalysisResultData.Curve"] = Dict()
-                    # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                     for (nw, nw_data) in solution_math["nw"]
                         mn_info = Dict(
-                            "ArCurveData.xvalue" => parse(Float64, nw),
+                            "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                             "ArCurveData.DataValues" => Dict(
                                 "AvStatus.inService" => elemtn_status
                             ),
@@ -419,7 +416,7 @@ function transform_solution_ravens(
     end
 
     # Nodal elements (loads, gens)
-    node_elements = ["load", "gen"]
+    node_elements = ["load", "gen", "storage"]
     for node_elmnt in node_elements
 
         for (node_number, node_data) in get(solution, node_elmnt, Dict{Any,Dict{String,Any}}())
@@ -436,6 +433,9 @@ function transform_solution_ravens(
                 elseif node_elmnt == "gen"
                     p_key = "pg"
                     q_key = "qg"
+                elseif node_elmnt == "storage"
+                    p_key = "ps"
+                    q_key = "qs"
                 else
                     p_key = "p"
                     q_key = "q"
@@ -453,13 +453,12 @@ function transform_solution_ravens(
                         # Curve data
                         mn_data = Dict()
                         mn_data["AnalysisResultData.Curve"] = Dict()
-                        # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                         for (nw, nw_data) in solution_math["nw"]
                             mn_info = Dict(
-                                "ArCurveData.xvalue" => parse(Float64, nw),
+                                "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                                 "ArCurveData.DataValues" => Dict(
                                     "AvPowerFlow.p" => solution_math["nw"][nw][node_elmnt][node_number][p_key][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
                                     "AvPowerFlow.q" => solution_math["nw"][nw][node_elmnt][node_number][q_key][i]*solution_math["nw"][nw]["settings"]["power_scale_factor"],
@@ -510,14 +509,13 @@ function transform_solution_ravens(
                     # Curve data
                     mn_data = Dict()
                     mn_data["AnalysisResultData.Curve"] = Dict()
-                    # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
                     for (nw, nw_data) in solution_math["nw"]
                         elemtn_status = Int(nw_data[node_elmnt][node_number]["status"]) == 1 ? true : false
                         mn_info = Dict(
-                            "ArCurveData.xvalue" => parse(Float64, nw),
+                            "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                             "ArCurveData.DataValues" => Dict(
                                 "AvStatus.inService" => elemtn_status
                             ),

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -116,6 +116,8 @@ function transform_solution_ravens(
 
     end
 
+    # Switches States
+    solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Switches"] = []
 
     edge_elements = ["branch", "switch"]
     for edge_elmnt in edge_elements
@@ -127,6 +129,19 @@ function transform_solution_ravens(
 
                 cond_eq_type = split(data_math[edge_elmnt][edge_number]["source_id"], '.')[1]
                 cond_eq_name = split(data_math[edge_elmnt][edge_number]["source_id"], '.')[2]
+
+                # Add Switch state (only switches)
+                if edge_elmnt == "switch"
+                    sw_state = data_math[edge_elmnt][edge_number]["state"] == 1 ? false : true
+                    state_info = Dict(
+                    "ArSwitch.Switch" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                    "AnalysisResultData.DataValues" => Dict(
+                        "AvSwitch.open" => sw_state,
+                        )
+                    )
+                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Switches"], state_info)
+                end
+
 
                 num_ends = 2
                 # # OPTIONAL opt out of edge elements beside transformers to write from and to flows
@@ -246,13 +261,6 @@ function transform_solution_ravens(
         end
     end
 
-
-    # @info "$(solution_ravens)"
-
-    open("./OPFTEST-mod.json","w") do f
-        JSON.print(f, solution_ravens, 2)
-    end
-
-    asdasd
+    return solution_ravens
 
 end

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -22,14 +22,12 @@ function transform_solution_ravens(
         dimensionalize_math_extensions=dimensionalize_math_extensions
     )
 
-    # TODO: multinetwork/multiperiod support
-    # if ismultinetwork(data_math)
-    #     nws_math_sol = get(solution_math, "nw", Dict{String,Any}())
-    #     nws_math_data = data_math["nw"]
-    # else
-    #     nws_math_sol = Dict("0" => solution_math)
-    #     nws_math_data = Dict("0" => data_math)
-    # end
+    # multinetwork/multiperiod support
+    if ismultinetwork(data_math)
+        nws_math_data = data_math["nw"]
+    else
+        nws_math_data = data_math
+    end
 
     # Create OptimalPowerFlow AnalysisResult Dictionary
     # TODO: read original JSON file, and add result to that JSON file (check if AnalysisResult exists before overwriting it)
@@ -45,25 +43,6 @@ function transform_solution_ravens(
 
     # Voltages
     solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"] = []
-    for (node_number, node_data) in solution_math["bus"]
-        # Extract the phases for the node
-        node_terminals = data_math["bus"][node_number]["terminals"]
-        phase_kinds = [phase_mapping[x] for x in node_terminals]
-
-        for (i, result_phase) in enumerate(phase_kinds)
-            conn_node = split(data_math["bus"][node_number]["source_id"], '.')[2]
-            voltage_info = Dict(
-                "AnalysisResultData.phase" => result_phase,
-                "ArVoltage.ConnectivityNode" => "ConnectivityNode::'$(conn_node)'",
-                "AnalysisResultData.DataValues" => Dict(
-                    "AvVoltage.v" => node_data["vm"][i]*solution_math["settings"]["voltage_scale_factor"],
-                    "AvVoltage.angle" => node_data["va"][i],
-                    "Ravens.cimObjectType" => "AvVoltage",
-                ),
-            )
-            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"], voltage_info)
-        end
-    end
 
     # PowerFlows
     solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"] = []
@@ -71,97 +50,236 @@ function transform_solution_ravens(
     # Statuses
     solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"] = []
 
-    # PowerFlow solutions for Transformers elements
-    seen_xfrmrs = Set{String}()     # Set to save xfrmr names
-    for (xfrmr_number, xfrmr_data) in get(solution_math, "transformer", Dict{Any,Dict{String,Any}}())
-
-        source_id_vect = split(data_math["transformer"][xfrmr_number]["source_id"], '.')
-        cond_eq_type = source_id_vect[2]
-        cond_eq_name = source_id_vect[3]
-        end_num = parse(Int, source_id_vect[4])
-
-        # Extract the phases for the branch
-        terminals = data_math["transformer"][xfrmr_number]["f_connections"]
-        phase_kinds = [phase_mapping[x] for x in terminals]
-
-        for (i, result_phase) in enumerate(phase_kinds)
-
-            pf_info = Dict(
-                "AnalysisResultData.phase" => result_phase,
-                "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
-                "AnalysisResultData.DataValues" => Dict(
-                    "AvPowerFlow.p" => xfrmr_data["pf"][i]*solution_math["settings"]["power_scale_factor"],
-                    "AvPowerFlow.q" => xfrmr_data["qf"][i]*solution_math["settings"]["power_scale_factor"],
-                    "AvPowerFlow.endNumber" => end_num,
-                    "Ravens.cimObjectType" => "ArPowerFlow",
-                ),
-            )
-            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
-
-        end
-
-        if !(cond_eq_name in seen_xfrmrs)
-            xfrmr_status = data_math["transformer"][xfrmr_number]["status"] == 1 ? true : false
-            status_info = Dict(
-                "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
-                "AnalysisResultData.DataValues" => Dict(
-                    "AvStatus.inService" => xfrmr_status,
-                )
-            )
-            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
-        end
-
-        # Store the xfrmr name
-        push!(seen_xfrmrs, "$(cond_eq_name)")
-
-    end
-
     # Switches States
     solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Switches"] = []
 
-    edge_elements = ["branch", "switch"]
-    for edge_elmnt in edge_elements
+    # PowerFlow solutions for Transformers elements
+    seen_xfrmrs = Set{String}()     # Set to save xfrmr names
 
-        for (edge_number, edge_data) in get(solution_math, edge_elmnt, Dict{Any,Dict{String,Any}}())
+    # Multinetwork support
+    if ismultinetwork(data_math)
 
-            # Filter virtual elements that exist in the MATH model
-            if !occursin("virtual", data_math[edge_elmnt][edge_number]["name"])
+        # # Buses/ConnectivityNodes --- Assummes there is at least nw=1
+        for (node_number, node_data) in solution_math["nw"]["1"]["bus"]
 
-                cond_eq_type = split(data_math[edge_elmnt][edge_number]["source_id"], '.')[1]
-                cond_eq_name = split(data_math[edge_elmnt][edge_number]["source_id"], '.')[2]
+            # Extract the phases for the node
+            node_terminals = nws_math_data["1"]["bus"][node_number]["terminals"]
+            phase_kinds = [phase_mapping[x] for x in node_terminals]
 
-                # Add Switch state (only switches)
-                if edge_elmnt == "switch"
-                    sw_state = data_math[edge_elmnt][edge_number]["state"] == 1 ? false : true
-                    state_info = Dict(
-                    "ArSwitch.Switch" => "$(cond_eq_type)::'$(cond_eq_name)'",
-                    "AnalysisResultData.DataValues" => Dict(
-                        "AvSwitch.open" => sw_state,
+            for (i, result_phase) in enumerate(phase_kinds)
+
+                conn_node = split(nws_math_data["1"]["bus"][node_number]["source_id"], '.')[2]
+
+                # Curve data
+                mn_data = Dict()
+                mn_data["AnalysisResultData.Curve"] = Dict()
+                # TODO: obtain this information from pmd_data_math["nw"]["1"]["time_elapsed"]
+                mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
+                mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
+
+                for (nw, nw_data) in solution_math["nw"]
+                    mn_info = Dict(
+                            "ArCurveData.xvalue" => parse(Float64, nw),
+                            "ArCurveData.DataValues" => Dict(
+                                "AvVoltage.v" => solution_math["nw"][nw]["bus"][node_number]["vm"][i]*solution_math["nw"][nw]["settings"]["voltage_scale_factor"],
+                                "AvVoltage.angle" => solution_math["nw"][nw]["bus"][node_number]["va"][i],
+                                "Ravens.cimObjectType" => "AvVoltage",
+                            ),
                         )
-                    )
-                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Switches"], state_info)
+                     push!(mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"], mn_info)
                 end
 
+                voltage_info = Dict(
+                    "AnalysisResultData.phase" => result_phase,
+                    "ArVoltage.ConnectivityNode" => "ConnectivityNode::'$(conn_node)'",
+                    "AnalysisResultData.Curve" => mn_data["AnalysisResultData.Curve"]
+                )
+                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"], voltage_info)
 
-                num_ends = 2
-                # # OPTIONAL opt out of edge elements beside transformers to write from and to flows
-                # if edge_elmnt != "transformer"
-                #     num_ends = 1
-                # end
+            end
+        end
 
-                for end_num in 1:num_ends # loop through ends
-                    if end_num == 1
-                        connection_flow = "f_connections"
-                        p_flow_direction = "pf"
-                        q_flow_direction = "qf"
-                    else end_num == 2
-                        connection_flow = "t_connections"
-                        p_flow_direction = "pt"
-                        q_flow_direction = "qt"
+
+
+
+
+
+    else
+
+        # Buses/ConnectivityNodes
+        for (node_number, node_data) in solution_math["bus"]
+            # Extract the phases for the node
+            node_terminals = nws_math_data["bus"][node_number]["terminals"]
+            phase_kinds = [phase_mapping[x] for x in node_terminals]
+
+            for (i, result_phase) in enumerate(phase_kinds)
+                conn_node = split(nws_math_data["bus"][node_number]["source_id"], '.')[2]
+                voltage_info = Dict(
+                    "AnalysisResultData.phase" => result_phase,
+                    "ArVoltage.ConnectivityNode" => "ConnectivityNode::'$(conn_node)'",
+                    "AnalysisResultData.DataValues" => Dict(
+                        "AvVoltage.v" => node_data["vm"][i]*solution_math["settings"]["voltage_scale_factor"],
+                        "AvVoltage.angle" => node_data["va"][i],
+                        "Ravens.cimObjectType" => "AvVoltage",
+                    ),
+                )
+                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Voltages"], voltage_info)
+            end
+        end
+
+        # Transformers
+        for (xfrmr_number, xfrmr_data) in get(solution_math, "transformer", Dict{Any,Dict{String,Any}}())
+
+            # Extract data
+            source_id_vect = split(nws_math_data["transformer"][xfrmr_number]["source_id"], '.')
+            cond_eq_type = source_id_vect[2]
+            cond_eq_name = source_id_vect[3]
+            end_num = parse(Int, source_id_vect[4])
+
+            # Extract the phases for the branch
+            terminals = nws_math_data["transformer"][xfrmr_number]["f_connections"]
+            phase_kinds = [phase_mapping[x] for x in terminals]
+
+            for (i, result_phase) in enumerate(phase_kinds)
+
+                pf_info = Dict(
+                    "AnalysisResultData.phase" => result_phase,
+                    "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                    "AnalysisResultData.DataValues" => Dict(
+                        "AvPowerFlow.p" => xfrmr_data["pf"][i]*solution_math["settings"]["power_scale_factor"],
+                        "AvPowerFlow.q" => xfrmr_data["qf"][i]*solution_math["settings"]["power_scale_factor"],
+                        "AvPowerFlow.endNumber" => end_num,
+                        "Ravens.cimObjectType" => "ArPowerFlow",
+                    ),
+                )
+                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+
+            end
+
+            if !(cond_eq_name in seen_xfrmrs)
+                xfrmr_status = nws_math_data["transformer"][xfrmr_number]["status"] == 1 ? true : false
+                status_info = Dict(
+                    "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                    "AnalysisResultData.DataValues" => Dict(
+                        "AvStatus.inService" => xfrmr_status,
+                    )
+                )
+                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+            end
+
+            # Store the xfrmr name
+            push!(seen_xfrmrs, "$(cond_eq_name)")
+
+        end
+
+        # Edge elements (branches, switches)
+        edge_elements = ["branch", "switch"]
+        for edge_elmnt in edge_elements
+
+            for (edge_number, edge_data) in get(solution_math, edge_elmnt, Dict{Any,Dict{String,Any}}())
+
+                # Filter virtual elements that exist in the MATH model
+                if !occursin("virtual", nws_math_data[edge_elmnt][edge_number]["name"])
+
+                    cond_eq_type = split(nws_math_data[edge_elmnt][edge_number]["source_id"], '.')[1]
+                    cond_eq_name = split(nws_math_data[edge_elmnt][edge_number]["source_id"], '.')[2]
+
+                    # Add Switch state (only switches)
+                    if edge_elmnt == "switch"
+                        sw_state = nws_math_data[edge_elmnt][edge_number]["state"] == 1 ? false : true
+                        state_info = Dict(
+                        "ArSwitch.Switch" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                        "AnalysisResultData.DataValues" => Dict(
+                            "AvSwitch.open" => sw_state,
+                            )
+                        )
+                        push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Switches"], state_info)
                     end
 
-                    # Extract the phases for the branch
-                    terminals = data_math[edge_elmnt][edge_number][connection_flow]
+
+                    num_ends = 2
+                    # # OPTIONAL opt out of edge elements beside transformers to write from and to flows
+                    # if edge_elmnt != "transformer"
+                    #     num_ends = 1
+                    # end
+
+                    for end_num in 1:num_ends # loop through ends
+                        if end_num == 1
+                            connection_flow = "f_connections"
+                            p_flow_direction = "pf"
+                            q_flow_direction = "qf"
+                        else end_num == 2
+                            connection_flow = "t_connections"
+                            p_flow_direction = "pt"
+                            q_flow_direction = "qt"
+                        end
+
+                        # Extract the phases for the branch
+                        terminals = nws_math_data[edge_elmnt][edge_number][connection_flow]
+                        phase_kinds = [phase_mapping[x] for x in terminals]
+
+                        for (i, result_phase) in enumerate(phase_kinds)
+
+                            pf_info = Dict(
+                                "AnalysisResultData.phase" => result_phase,
+                                "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                                "AnalysisResultData.DataValues" => Dict(
+                                    "AvPowerFlow.p" => edge_data[p_flow_direction][i]*solution_math["settings"]["power_scale_factor"],
+                                    "AvPowerFlow.q" => edge_data[q_flow_direction][i]*solution_math["settings"]["power_scale_factor"],
+                                    "AvPowerFlow.endNumber" => end_num,
+                                    "Ravens.cimObjectType" => "ArPowerFlow",
+                                ),
+                            )
+                            push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+
+                        end
+                    end
+
+                    # Statuses
+                    object_prefix = ""
+                    if edge_elmnt == "branch"
+                        object_prefix = "br_"
+                    end
+
+                    elemtn_status = nws_math_data[edge_elmnt][edge_number]["$(object_prefix)status"] == 1 ? true : false
+                    status_info = Dict(
+                        "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                        "AnalysisResultData.DataValues" => Dict(
+                            "AvStatus.inService" => elemtn_status,
+                        )
+                    )
+                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+
+                end
+
+            end
+        end
+
+        # Nodal elements (loads, gens)
+        node_elements = ["load", "gen"]
+        for node_elmnt in node_elements
+
+            for (node_number, node_data) in get(solution_math, node_elmnt, Dict{Any,Dict{String,Any}}())
+
+                # Filter virtual elements that exist in the MATH model
+                if !occursin("virtual", nws_math_data[node_elmnt][node_number]["name"])
+
+                    cond_eq_type = split(nws_math_data[node_elmnt][node_number]["source_id"], '.')[1]
+                    cond_eq_name = split(nws_math_data[node_elmnt][node_number]["source_id"], '.')[2]
+
+                    if node_elmnt == "load"
+                        p_key = "pd"
+                        q_key = "qd"
+                    elseif node_elmnt == "gen"
+                        p_key = "pg"
+                        q_key = "qg"
+                    else
+                        p_key = "p"
+                        q_key = "q"
+                    end
+
+                    # Extract the phases for the node element
+                    terminals = nws_math_data[node_elmnt][node_number]["connections"]
                     phase_kinds = [phase_mapping[x] for x in terminals]
 
                     for (i, result_phase) in enumerate(phase_kinds)
@@ -170,96 +288,35 @@ function transform_solution_ravens(
                             "AnalysisResultData.phase" => result_phase,
                             "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
                             "AnalysisResultData.DataValues" => Dict(
-                                "AvPowerFlow.p" => edge_data[p_flow_direction][i]*solution_math["settings"]["power_scale_factor"],
-                                "AvPowerFlow.q" => edge_data[q_flow_direction][i]*solution_math["settings"]["power_scale_factor"],
-                                "AvPowerFlow.endNumber" => end_num,
+                                "AvPowerFlow.p" => node_data[p_key][i]*solution_math["settings"]["power_scale_factor"],
+                                "AvPowerFlow.q" => node_data[q_key][i]*solution_math["settings"]["power_scale_factor"],
                                 "Ravens.cimObjectType" => "ArPowerFlow",
                             ),
                         )
                         push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
-
                     end
-                end
 
-                # Statuses
-                object_prefix = ""
-                if edge_elmnt == "branch"
-                    object_prefix = "br_"
-                end
 
-                elemtn_status = data_math[edge_elmnt][edge_number]["$(object_prefix)status"] == 1 ? true : false
-                status_info = Dict(
-                    "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
-                    "AnalysisResultData.DataValues" => Dict(
-                        "AvStatus.inService" => elemtn_status,
-                    )
-                )
-                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
+                    # Statuses
+                    object_prefix = ""
+                    if node_elmnt == "gen"
+                        object_prefix = "gen_"
+                    end
 
-            end
-
-        end
-    end
-
-    #  PowerFlow solutions for Node elements
-    node_elements = ["load", "gen"]
-    for node_elmnt in node_elements
-
-        for (node_number, node_data) in get(solution_math, node_elmnt, Dict{Any,Dict{String,Any}}())
-
-            # Filter virtual elements that exist in the MATH model
-            if !occursin("virtual", data_math[node_elmnt][node_number]["name"])
-
-                cond_eq_type = split(data_math[node_elmnt][node_number]["source_id"], '.')[1]
-                cond_eq_name = split(data_math[node_elmnt][node_number]["source_id"], '.')[2]
-
-                if node_elmnt == "load"
-                    p_key = "pd"
-                    q_key = "qd"
-                elseif node_elmnt == "gen"
-                    p_key = "pg"
-                    q_key = "qg"
-                else
-                    p_key = "p"
-                    q_key = "q"
-                end
-
-                # Extract the phases for the node element
-                terminals = data_math[node_elmnt][node_number]["connections"]
-                phase_kinds = [phase_mapping[x] for x in terminals]
-
-                for (i, result_phase) in enumerate(phase_kinds)
-
-                    pf_info = Dict(
-                        "AnalysisResultData.phase" => result_phase,
-                        "ArPowerFlow.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
+                    elemtn_status = nws_math_data[node_elmnt][node_number]["$(object_prefix)status"] == 1 ? true : false
+                    status_info = Dict(
+                        "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
                         "AnalysisResultData.DataValues" => Dict(
-                            "AvPowerFlow.p" => node_data[p_key][i]*solution_math["settings"]["power_scale_factor"],
-                            "AvPowerFlow.q" => node_data[q_key][i]*solution_math["settings"]["power_scale_factor"],
-                            "Ravens.cimObjectType" => "ArPowerFlow",
-                        ),
+                            "AvStatus.inService" => elemtn_status,
+                        )
                     )
-                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.PowerFlows"], pf_info)
+                    push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
                 end
-
-
-                # Statuses
-                object_prefix = ""
-                if node_elmnt == "gen"
-                    object_prefix = "gen_"
-                end
-
-                elemtn_status = data_math[node_elmnt][node_number]["$(object_prefix)status"] == 1 ? true : false
-                status_info = Dict(
-                    "ArStatus.ConductingEquipment" => "$(cond_eq_type)::'$(cond_eq_name)'",
-                    "AnalysisResultData.DataValues" => Dict(
-                        "AvStatus.inService" => elemtn_status,
-                    )
-                )
-                push!(solution_ravens["AnalysisResult"]["OptimalPowerFlow"]["OperationsResult.Statuses"], status_info)
             end
         end
+
     end
+
 
     return solution_ravens
 

--- a/src/data_model/transformations/math2ravens.jl
+++ b/src/data_model/transformations/math2ravens.jl
@@ -29,6 +29,11 @@ function transform_solution_ravens(
         nws_math_data = data_math["nw"]["1"]
         solution = solution_math["nw"]["1"]
         mn_flag = true
+
+        # sort nw keys (ensures vectors are organized in RAVENS)
+        keys_array = collect(keys(solution_math["nw"]))
+        sorted_nws = sort(keys_array, by=x -> parse(Int, x))
+
     else
         nws_math_data = data_math
         solution = solution_math
@@ -84,7 +89,7 @@ function transform_solution_ravens(
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
-                for (nw, nw_data) in solution_math["nw"]
+                for nw in sorted_nws
                     mn_info = Dict(
                         "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                         "ArCurveData.DataValues" => Dict(
@@ -150,7 +155,7 @@ function transform_solution_ravens(
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
-                for (nw, nw_data) in solution_math["nw"]
+                for nw in sorted_nws
                     mn_info = Dict(
                         "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                         "ArCurveData.DataValues" => Dict(
@@ -203,7 +208,7 @@ function transform_solution_ravens(
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                 mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
-                for (nw, nw_data) in solution_math["nw"]
+                for nw in sorted_nws
                     mn_info = Dict(
                         "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                         "ArCurveData.DataValues" => Dict(
@@ -264,9 +269,9 @@ function transform_solution_ravens(
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
-                        for (nw, nw_data) in solution_math["nw"]
-                            if haskey(nw_data[edge_elmnt][edge_number], "state")
-                                sw_state = Int(nw_data[edge_elmnt][edge_number]["state"]) == 0 ? true : false
+                        for nw in sorted_nws
+                            if haskey(solution_math["nw"][nw][edge_elmnt][edge_number], "state")
+                                sw_state = Int(solution_math["nw"][nw][edge_elmnt][edge_number]["state"]) == 0 ? true : false
                             end
                             mn_info = Dict(
                                 "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
@@ -329,7 +334,7 @@ function transform_solution_ravens(
                             mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                             mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
-                            for (nw, nw_data) in solution_math["nw"]
+                            for nw in sorted_nws
                                 mn_info = Dict(
                                     "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                                     "ArCurveData.DataValues" => Dict(
@@ -384,7 +389,7 @@ function transform_solution_ravens(
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
-                    for (nw, nw_data) in solution_math["nw"]
+                    for nw in sorted_nws
                         mn_info = Dict(
                             "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                             "ArCurveData.DataValues" => Dict(
@@ -458,7 +463,7 @@ function transform_solution_ravens(
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                         mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
-                        for (nw, nw_data) in solution_math["nw"]
+                        for nw in sorted_nws
                             mn_info = Dict(
                                 "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],
                                 "ArCurveData.DataValues" => Dict(
@@ -514,9 +519,9 @@ function transform_solution_ravens(
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.xUnit"] = "UnitSymbol.h"
                     mn_data["AnalysisResultData.Curve"]["AnalysisResultCurve.CurveDatas"] = []
 
-                    for (nw, nw_data) in solution_math["nw"]
-                        if haskey(nw_data[node_elmnt][node_number], "status")
-                            elemtn_status = Int(nw_data[node_elmnt][node_number]["status"]) == 1 ? true : false
+                    for nw in sorted_nws
+                        if haskey(solution_math["nw"][nw][node_elmnt][node_number], "status")
+                            elemtn_status = Int(solution_math["nw"][nw][node_elmnt][node_number]["status"]) == 1 ? true : false
                         end
                         mn_info = Dict(
                             "ArCurveData.xvalue" => parse(Float64, nw)*data_math["nw"][nw]["time_elapsed"],


### PR DESCRIPTION
Adds a function with  the following signature:

```
function transform_solution_ravens(solution_math, data_math)
```

This function takes the solution in MATH and the network data in MATH. It returns a dictionary, based on CIM-MG-RAVENS format, that contains the PF/OPF solutions. It works with both PMD and ONM solutions.

